### PR TITLE
Remove keyspace name in cql when creating tables

### DIFF
--- a/src/main/resources/import_history.cql
+++ b/src/main/resources/import_history.cql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS import_history.files (
+CREATE TABLE IF NOT EXISTS files (
     filename text,
     origin text,
     import_date timestamp,

--- a/src/test/java/org/gridsuite/cases/importer/job/CaseAcquisitionJobTest.java
+++ b/src/test/java/org/gridsuite/cases/importer/job/CaseAcquisitionJobTest.java
@@ -42,7 +42,7 @@ public class CaseAcquisitionJobTest {
 
     @ClassRule
     public static final CassandraRule CASSANDRA_RULE = new CassandraRule().withCassandraFactory(EmbeddedCassandraFactoryConfig.embeddedCassandraFactory())
-                                                                          .withCqlDataSet(CqlDataSet.ofClasspaths("create_keyspace.cql", "import_history.cql"));
+                                                                          .withCqlDataSet(CqlDataSet.ofClasspaths("create_keyspace.cql").add(CqlDataSet.ofStrings("USE import_history;")).add(CqlDataSet.ofClasspaths("import_history.cql")));
 
     @ClassRule
     public static final FakeSftpServerRule SFTP_SERVER_RULE = new FakeSftpServerRule().addUser("dummy", "dummy").setPort(2222);


### PR DESCRIPTION
otherwise it can't work with other keyspace name (ex: prefixed names), fix test conf as well

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>